### PR TITLE
KT1-132: feat(notification): 알림 발송 기록 기능 구현

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,8 @@ from app.utils.logger import setup_logging
 import logging
 
 from app.utils.db import Base, engine
-from app.models import report # Report 모델 임포트
+# Import all models to ensure they are registered with Base
+from app.models import report, notification_log
 
 logger = logging.getLogger(__name__)
 

--- a/app/api/notification_router.py
+++ b/app/api/notification_router.py
@@ -1,8 +1,11 @@
-from fastapi import APIRouter, HTTPException, status
-from app.core import aws_notification_service
+from fastapi import APIRouter, HTTPException, status, Depends
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from app.core import aws_notification_service, crud_service
 from app.helper import verification_helper, notification_helper
-from app.schemas.notification_schemas import EmailRequest, SmsRequest
-from app.schemas.verification_schemas import PhoneNumberRequest, VerificationCodeRequest
+from app import schemas
+from app.utils.db import get_db
 
 router = APIRouter(
     prefix="/notifications",
@@ -10,7 +13,7 @@ router = APIRouter(
 )
 
 @router.post("/send-email")
-async def send_email_notification(request: EmailRequest):
+async def send_email_notification(request: schemas.EmailRequest):
     success = aws_notification_service.send_email(
         request.sender_email,
         request.recipient_email,
@@ -22,7 +25,7 @@ async def send_email_notification(request: EmailRequest):
     return {"message": "이메일이 성공적으로 발송되었습니다."}
 
 @router.post("/send-sms")
-async def send_sms_notification(request: SmsRequest):
+async def send_sms_notification(request: schemas.SmsRequest):
     success = aws_notification_service.send_sms(
         request.phone_number,
         request.message
@@ -32,7 +35,7 @@ async def send_sms_notification(request: SmsRequest):
     return {"message": "SMS가 성공적으로 발송되었습니다."}
 
 @router.post("/phone/send-code")
-async def send_phone_verification_code(request: PhoneNumberRequest):
+async def send_phone_verification_code(request: schemas.PhoneNumberRequest):
     """전화번호 인증 코드를 생성하고 SMS로 발송합니다."""
     code = verification_helper.generate_verification_code(request.phone_number)
     success = aws_notification_service.send_verification_sms(request.phone_number, code)
@@ -41,7 +44,7 @@ async def send_phone_verification_code(request: PhoneNumberRequest):
     return {"message": "인증 코드가 성공적으로 발송되었습니다."}
 
 @router.post("/phone/verify-code")
-async def verify_phone_code(request: VerificationCodeRequest):
+async def verify_phone_code(request: schemas.VerificationCodeRequest):
     """제출된 인증 코드를 검증합니다."""
     success = verification_helper.verify_code(request.phone_number, request.verification_code)
     if not success:
@@ -54,3 +57,18 @@ async def generate_weekly_reports_manually():
     """
     await notification_helper.send_weekly_reports()
     return {"message": "주간 보고서 생성이 트리거되었습니다."}
+
+@router.get("/history", response_model=List[schemas.NotificationLog])
+def get_notification_history(
+    recipient_user_id: Optional[int] = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db)
+):
+    """
+    Retrieve notification history. Can be filtered by recipient_user_id.
+    """
+    logs = crud_service.get_notification_logs(
+        db=db, recipient_user_id=recipient_user_id, skip=skip, limit=limit
+    )
+    return logs

--- a/app/core/crud_service.py
+++ b/app/core/crud_service.py
@@ -1,13 +1,17 @@
 from sqlalchemy.orm import Session
-from app.models.report import Report
-from app.schemas.report_schema import ReportCreate
 from datetime import datetime, timedelta
+from typing import List, Optional
 
-def create_report(db: Session, report: ReportCreate):
+# Import models and schemas
+from app import models
+from app import schemas
+
+
+def def create_report(db: Session, report: schemas.ReportCreate) -> models.Report:
     kst_now = datetime.utcnow() + timedelta(hours=9)
-    db_report = Report(
+    db_report = models.Report(
         user_id=report.user_id, 
-        report_data=report.report_data, # report_data 저장
+        report_data=report.report_data,
         report_date=kst_now
     )
     db.add(db_report)
@@ -15,4 +19,35 @@ def create_report(db: Session, report: ReportCreate):
     db.refresh(db_report)
     return db_report
 
-# 필요하다면 다른 CRUD 함수 (read, update, delete)도 여기에 추가할 수 있습니다.
+# NotificationLog CRUD operations
+
+def create_notification_log(db: Session, log: schemas.NotificationLogCreate) -> models.NotificationLog:
+    """
+    Create a new notification log entry.
+    """
+    db_log = models.NotificationLog(
+        triggering_user_id=log.triggering_user_id,
+        recipient_user_id=log.recipient_user_id,
+        message=log.message,
+        status=log.status,
+        provider_response=log.provider_response
+    )
+    db.add(db_log)
+    db.commit()
+    db.refresh(db_log)
+    return db_log
+
+def get_notification_logs(
+    db: Session,
+    recipient_user_id: Optional[int] = None,
+    skip: int = 0,
+    limit: int = 100
+) -> List[models.NotificationLog]:
+    """
+    Retrieve notification logs, with optional filtering by recipient user ID.
+    """
+    query = db.query(models.NotificationLog).order_by(models.NotificationLog.sent_at.desc())
+    if recipient_user_id:
+        query = query.filter(models.NotificationLog.recipient_user_id == recipient_user_id)
+    
+    return query.offset(skip).limit(limit).all()

--- a/app/helper/notification_helper.py
+++ b/app/helper/notification_helper.py
@@ -4,7 +4,7 @@ import datetime
 from datetime import timedelta
 from app.config.config import Config
 from app.core import aws_notification_service, crud_service, user_service_client, daily_question_service_client
-from app.schemas.report_schema import ReportCreate
+from app import schemas # Import schemas
 from app.utils.db import SessionLocal
 from sqlalchemy.orm import Session
 
@@ -18,20 +18,47 @@ async def send_alert_to_guardians(user_id: int, reasons: list):
         return
 
     notification_reason = " ".join(reasons)
-    for guardian in guardians:
-        guardian_email = guardian.get('email')
-        guardian_phone = guardian.get('phone_number')
-        relationship_display_name = guardian.get('relationship_display_name', '보호자')
-        notification_message = f"[기억의 정원] {relationship_display_name}님의 최근 활동에 주의가 필요하여 알려드립니다. 사유: {notification_reason}"
-        
-        if guardian_phone:
-            if not guardian_phone.startswith('+'):
-                guardian_phone = "+82" + guardian_phone[1:]
-            aws_notification_service.send_sms(
-                phone_number=guardian_phone,
-                message=notification_message
-            )
-            logger.info(f"SMS 알림 발송 시도: {guardian_phone}")
+    
+    db: Session = SessionLocal()
+    try:
+        for guardian in guardians:
+            guardian_id = guardian.get('id')
+            guardian_phone = guardian.get('phone_number')
+            relationship_display_name = guardian.get('relationship_display_name', '보호자')
+            notification_message = f"[기억의 정원] {relationship_display_name}님의 최근 활동에 주의가 필요하여 알려드립니다. 사유: {notification_reason}"
+            
+            status = "failed"
+            provider_response = None
+
+            if guardian_phone and guardian_id:
+                if not guardian_phone.startswith('+'):
+                    guardian_phone = "+82" + guardian_phone[1:]
+                
+                # Assuming send_sms returns a boolean for success
+                success = aws_notification_service.send_sms(
+                    phone_number=guardian_phone,
+                    message=notification_message
+                )
+                
+                if success:
+                    status = "sent"
+                
+                logger.info(f"SMS 알림 발송 시도: {guardian_phone}, 상태: {status}")
+
+                # Create and save the notification log
+                log_entry = schemas.NotificationLogCreate(
+                    triggering_user_id=user_id,
+                    recipient_user_id=guardian_id,
+                    message=notification_message,
+                    status=status,
+                    provider_response=provider_response # Can be enhanced later
+                )
+                crud_service.create_notification_log(db=db, log=log_entry)
+                logger.info(f"Notification log created for recipient {guardian_id}")
+            else:
+                logger.info(f"Guardian {guardian.get('email')} is missing phone number or ID. Skipping SMS.")
+    finally:
+        db.close()
 
 async def process_score_update_message(message_payload: dict):
     user_id = message_payload.get('user_id')
@@ -108,7 +135,7 @@ async def send_weekly_reports():
 
         db: Session = SessionLocal()
         try:
-            report_create_schema = ReportCreate(
+            report_create_schema = schemas.ReportCreate(
                 user_id=senior_id,
                 report_data=report_data
             )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .notification_log import NotificationLog
+from .report import Report

--- a/app/models/notification_log.py
+++ b/app/models/notification_log.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+from app.utils.db import Base
+
+class NotificationLog(Base):
+    __tablename__ = "notification_logs"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    triggering_user_id = Column(Integer, nullable=False, index=True)
+    recipient_user_id = Column(Integer, nullable=False, index=True)
+    message = Column(Text, nullable=False)
+    status = Column(String, nullable=False)
+    provider_response = Column(JSONB, nullable=True)
+    sent_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .notification_log_schemas import NotificationLog, NotificationLogCreate
+from .notification_schemas import EmailRequest, SmsRequest
+from .verification_schemas import PhoneNumberRequest, VerificationCodeRequest
+from .report_schema import Report, ReportCreate

--- a/app/schemas/notification_log_schemas.py
+++ b/app/schemas/notification_log_schemas.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import Optional, Any
+
+# Base schema with common attributes
+class NotificationLogBase(BaseModel):
+    triggering_user_id: int
+    recipient_user_id: int
+    message: str
+    status: str
+
+    class Config:
+        orm_mode = True
+
+# Schema for creating a new log (used in service layer)
+class NotificationLogCreate(NotificationLogBase):
+    provider_response: Optional[dict] = None
+
+# Schema for reading a log from the API (includes DB-generated fields)
+class NotificationLog(NotificationLogBase):
+    id: int
+    sent_at: datetime
+    provider_response: Optional[Any] = None # Using Any for flexibility with JSONB


### PR DESCRIPTION
- SMS 알림 발송 시, 발송 기록을 DB에 저장하는 기능 추가
- `notification_logs` 테이블 모델 및 관련 스키마, CRUD 로직 생성
- `send_alert_to_guardians` 헬퍼에 로그 생성 로직 통합
- 저장된 알림 기록을 조회할 수 있는 `GET /notifications/history` API 엔드포인트 추가
- 앱 시작 시 `notification_logs` 테이블이 자동 생성되도록 모델 임포트 구문 수정